### PR TITLE
Add permission "allow everything" to adminhtml.xml to resolve admin 404 ...

### DIFF
--- a/app/code/community/Diglin/Username/etc/adminhtml.xml
+++ b/app/code/community/Diglin/Username/etc/adminhtml.xml
@@ -2,6 +2,9 @@
 <config>
     <acl>
         <resources>
+            <all>
+                <title>Allow Everything</title>
+            </all>
             <admin>
                 <children>
                     <system>


### PR DESCRIPTION
This resolves the 404 error in the admin screen for the extension in Magento CE 1.8.
