### PR TITLE
Add customer username to Magento API.

### DIFF
--- a/src/app/code/community/Diglin/Username/etc/wsdl.xml
+++ b/src/app/code/community/Diglin/Username/etc/wsdl.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:typens="urn:{{var wsdl.name}}" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/"
+    name="{{var wsdl.name}}" targetNamespace="urn:{{var wsdl.name}}">
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:Magento">
+            <import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/" />
+            <complexType name="customerCustomerEntityToCreate">
+                <all>
+                    <element name="username" type="xsd:string" minOccurs="0" />                    
+                </all>
+            </complexType>
+            <complexType name="customerCustomerEntity">
+                <all>
+                    <element name="username" type="xsd:string" minOccurs="0" />
+                </all>
+            </complexType>            
+        </schema>
+    </types>    
+</definitions>

--- a/src/app/code/community/Diglin/Username/etc/wsi.xml
+++ b/src/app/code/community/Diglin/Username/etc/wsi.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:typens="urn:{{var wsdl.name}}"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+             xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+             name="{{var wsdl.name}}"
+             targetNamespace="urn:{{var wsdl.name}}">
+    <wsdl:types>
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:{{var wsdl.name}}">
+            <xsd:complexType name="customerCustomerEntityToCreate">
+                <xsd:sequence>
+                    <xsd:element name="username" type="xsd:string" minOccurs="0" />                    
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="customerCustomerEntity">
+                <xsd:sequence>
+                    <xsd:element name="username" type="xsd:string" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:complexType>                   
+    </wsdl:types>
+</wsdl:definitions>


### PR DESCRIPTION
This change adds the new customer username field to the Magento API as well as the rest of the site. Allows creating new customers with username, or fetching it via customer list. 