### PR TITLE
Fix function validateData(array $data)

### DIFF
--- a/src/app/code/community/Diglin/Username/Model/Form.php
+++ b/src/app/code/community/Diglin/Username/Model/Form.php
@@ -53,7 +53,7 @@ class Diglin_Username_Model_Form extends Mage_Customer_Model_Form
         $errors = parent::validateData($data);
 
         // Prevent to change/save the username if it is not allowed on the frontend to change the username
-        if (!Mage::getStoreConfigFlag('username/general/frontend') && !Mage::app()->getStore()->isAdmin()) {
+        if (!Mage::getStoreConfigFlag('username/general/frontend') && !Mage::app()->getStore()->isAdmin() && $errors !== true) {
             return $errors;
         }
 
@@ -75,7 +75,7 @@ class Diglin_Username_Model_Form extends Mage_Customer_Model_Form
             }
 
             // Prevent possible errors
-            if (empty($customerId)) {
+            if (empty($customerId) && $errors !== true) {
                 return $errors;
             }
 


### PR DESCRIPTION
Current statement of function validateData(array $data) allowed any characters of username, for example: &^&*0234dv)@#

Fix: preventing disabled characters, according to the config settings:

Mage::getStoreConfig('username/general/input_validation')
Mage::getStoreConfig('username/general/input_validation_custom')