### PR TITLE
Prevent warning when using the module in PHP 7.2

### DIFF
--- a/src/app/code/community/Diglin/Username/Model/Form.php
+++ b/src/app/code/community/Diglin/Username/Model/Form.php
@@ -137,7 +137,7 @@ class Diglin_Username_Model_Form extends Mage_Customer_Model_Form
                 $errors = array_merge($errors, array($message));
             }
         }
-        if (count($errors) == 0) {
+        if (is_array($errors) && count($errors) == 0) {
             return true;
         }
         return $errors;


### PR DESCRIPTION
Prevents the following warning message if $errors is true from parent::validateData($data);

- Warning: count(): Parameter must be an array or an object that implements Countable  in vendor/diglin/diglin_username/src/app/code/community/Diglin/Username/Model/Form.php on line 141